### PR TITLE
update: test for https not http

### DIFF
--- a/REDHATTOOLSINSTALLER-6.6-Latest.sh
+++ b/REDHATTOOLSINSTALLER-6.6-Latest.sh
@@ -9,7 +9,7 @@ echo -ne "\e[8;40;170t"
 
 
 reset
-wget -q --tries=10 --timeout=20 --spider http://google.com
+wget -q --tries=10 --timeout=20 --spider https://google.com
 if [[ $? -eq 0 ]]; then
         echo "Online: Continuing to Install"
 else


### PR DESCRIPTION
error code 8 vs 0 which is success;
cf. https://venturebeat.com/2016/07/29/google-com-starts-redirecting-http-requests-to-https/